### PR TITLE
Authorization manager

### DIFF
--- a/src/main/scala/info/mukel/telegram/bots/AuthorizationManager.scala
+++ b/src/main/scala/info/mukel/telegram/bots/AuthorizationManager.scala
@@ -1,0 +1,63 @@
+package info.mukel.telegram.bots
+
+import info.mukel.telegram.bots.Policy._
+
+import scala.collection.mutable
+
+sealed trait Policy
+
+object Policy {
+  case object Accept extends Policy
+  case object Decline extends Policy
+}
+
+/**
+  * Filter the channels to which the bot could/should not respond
+  * Two policies are available:
+  *
+  * - Accept: respond to any channels, except the ones that are blacklisted
+  * - Decline: do not respond to any channels, except the ones that are whitelisted
+  */
+object AuthorizationManager {
+
+  private val authorizations =  mutable.Set[Int]()
+  private var policy : Policy = Accept
+
+  /**
+    * Finds if a channel is authorized or not
+    * @param channel
+    *   The channel to look the authorization for.
+    * @return
+    *   Whether or not the bot can respond to this channel
+    */
+  def isAuthorized(channel: Int) : Boolean = {
+    val authorization = authorizations.contains(channel)
+    policy match {
+      case Accept => !authorization
+      case Decline => authorization
+    }
+  }
+
+  /**
+    * Add a channel to the whitelisted/blacklisted
+    * @param channel
+    *   The channel to add
+    */
+  def add(channel: Int) = authorizations.add(channel)
+
+  /**
+    * Remove a channel to the whitelisted/blacklisted
+    * @param channel
+    *   The channel to add
+    */
+  def remove(channel: Int) = authorizations.remove(channel)
+
+  /**
+    * Set the Manager policy
+    * @param policy
+    *   The new authorization policy
+    */
+  def setPolicy(policy: Policy) = this.policy = policy
+
+}
+

--- a/src/main/scala/info/mukel/telegram/bots/Commands.scala
+++ b/src/main/scala/info/mukel/telegram/bots/Commands.scala
@@ -19,7 +19,7 @@ trait Commands {
   // Allows targeting specific bots eg. /hello@FlunkeyBot
   val cmdAt = "@"
 
-  private val commands = mutable.HashMap[String, (Int, Seq[String]) => Unit]()  
+  private val commands = mutable.HashMap[String, (Int, Seq[String]) => Unit]()
 
   /**
    * handleUpdate
@@ -44,7 +44,7 @@ trait Commands {
    */
   override def handleUpdate(update: Update): Unit = {
     for {
-      msg <- update.message
+      msg <- update.message if AuthorizationManager.isAuthorized(msg.chat.id)
       text <- msg.text
     } /* do */ {
 


### PR DESCRIPTION
The authorization manager takes care of the authorization when talking to a bot.
This way you could create a private bot that will only respond to specific channels.
The authorization can work either by whitelisting or blacklisting channels.
By default the policy is to accept all channels.

Waiting for a config file to add static channels to the list (currently this can only be done from the code)