### PR TITLE
EditMessageReplyMarkup can edit only inline reply markup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,21 @@
+*.class
+*.log
+
+# sbt specific
+.cache
+.history
+.lib/
+dist/*
+target/
+lib_managed/
+src_managed/
+project/boot/
+project/plugins/project/
+
+# Scala-IDE specific
+.scala_dependencies
+.worksheet
+
+credentials.*
+
+.DS_Store

--- a/src/main/scala/info/mukel/telegrambot4s/api/Commands.scala
+++ b/src/main/scala/info/mukel/telegrambot4s/api/Commands.scala
@@ -83,10 +83,7 @@ trait Commands extends BotBase {
     )
   }
 
-  private def cleanCmd(cmd: String): String = {
-    val cmdEnd = if (cmd.contains('@')) cmd.indexOf('@') else cmd.length
-    cmd.substring(0, cmdEnd).toLowerCase
-  }
+  private def cleanCmd(cmd: String): String = cmd.takeWhile(_ != '@').toLowerCase
 
   /** Makes the bot able react to 'command' with the specified handler.
     * 'action' receives a message and the arguments as parameters.

--- a/src/main/scala/info/mukel/telegrambot4s/methods/EditMessageReplyMarkup.scala
+++ b/src/main/scala/info/mukel/telegrambot4s/methods/EditMessageReplyMarkup.scala
@@ -1,6 +1,6 @@
 package info.mukel.telegrambot4s.methods
 
-import info.mukel.telegrambot4s.models.{Message, ReplyMarkup}
+import info.mukel.telegrambot4s.models.{Message, InlineKeyboardMarkup}
 
 /** Use this method to edit only the reply markup of messages sent by the bot or via the bot (for inline bots).
   * On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned.
@@ -14,5 +14,5 @@ case class EditMessageReplyMarkup(
                                  chatId          : Option[Long Either String] = None,
                                  messageId       : Option[Long] = None,
                                  inlineMessageId : Option[String] = None,
-                                 replyMarkup     : Option[ReplyMarkup] = None
+                                 replyMarkup     : Option[InlineKeyboardMarkup] = None
                                  ) extends ApiRequestJson[Message Either Boolean]


### PR DESCRIPTION
It's a minor fix. I discovered this issue trying to edit non-inline reply markup 😅 
[Docs](https://core.telegram.org/bots/api#editmessagereplymarkup) also mention it.

I also added a `.gitignore`. I'm not sure whether you didn't have it on purpose or not..