### PR TITLE
Create public command extractors, use them in Commands#onCommand

### DIFF
--- a/core/src/main/scala/info/mukel/telegrambot4s/api/Extractors.scala
+++ b/core/src/main/scala/info/mukel/telegrambot4s/api/Extractors.scala
@@ -1,6 +1,6 @@
 package info.mukel.telegrambot4s.api
 
-import info.mukel.telegrambot4s.api.declarative.Args
+import info.mukel.telegrambot4s.api.declarative._
 import info.mukel.telegrambot4s.models.Message
 
 import scala.util.Try
@@ -16,6 +16,21 @@ object Extractors {
     * Tokenize message text.
     */
   def textTokens(msg: Message): Option[Args] = msg.text.map(_.trim.split("\\s+"))
+
+  /**
+    * Extract clean command, lowercased and without receiver.
+    */
+  def command(msg: Message): Option[Command] =
+    rawCommand(msg).map(ToCommand.cleanCommand)
+
+  /**
+    * Extract trimmed command without '/'. Receiver is included, if exists.
+    */
+  def rawCommand(msg: Message): Option[Command] =
+    textTokens(msg)
+      .map(_.head)
+      .filter(_.startsWith(ToCommand.CommandPrefix))
+      .map(_.trim.stripPrefix(ToCommand.CommandPrefix))
 
   /**
     * Tokenize message text; drops first token (/command).

--- a/core/src/main/scala/info/mukel/telegrambot4s/api/declarative/Commands.scala
+++ b/core/src/main/scala/info/mukel/telegrambot4s/api/declarative/Commands.scala
@@ -45,17 +45,16 @@ trait Commands extends Messages with BotExecutionContext {
       "Commands cannot contain whitespace")
 
     onMessage { implicit msg =>
-      using(textTokens) { tokens =>
-        val cmd = tokens.head
-        // Filter only commands
-        if (cmd.startsWith(ToCommand.CommandPrefix)) {
-          val target = ToCommand.cleanCommand(cmd)
-          val optReceiver = ToCommand.getReceiver(cmd)
-          val matchReceiver = ignoreCommandReceiver || 
-            optReceiver.forall(_.equalsIgnoreCase(botName))
+      using(rawCommand) { rawCmd =>
+        val optReceiver = ToCommand.getReceiver(rawCmd)
+        val matchReceiver = ignoreCommandReceiver ||
+          optReceiver.forall(_.equalsIgnoreCase(botName))
 
-          if (matchReceiver && variants.contains(target))
-            action(msg)
+        if (matchReceiver) {
+          using(command) { cmd =>
+            if (variants.contains(cmd))
+              action(msg)
+          }
         }
       }
     }

--- a/core/src/main/scala/info/mukel/telegrambot4s/api/declarative/package.scala
+++ b/core/src/main/scala/info/mukel/telegrambot4s/api/declarative/package.scala
@@ -3,6 +3,7 @@ package info.mukel.telegrambot4s.api
 package object declarative {
   type Action[T] = T => Unit
   type Filter[T] = T => Boolean
+  type Command = String
   type Args = Seq[String]
   type ActionWithArgs[T] = T => Args => Unit
   type Extractor[T, R] = T => Option[R]


### PR DESCRIPTION
I'd like to be able to write such code:

```
onMessage { implicit msg =>
  using(command) { cmd =>
    ...
  }
}
```

Also, I refactored a bit Commands#onCommand method using new extractors.