### PR TITLE
Fixes wrong command in LmgtfyBot example

### DIFF
--- a/examples/src/main/scala/LmgtfyBot.scala
+++ b/examples/src/main/scala/LmgtfyBot.scala
@@ -49,7 +49,7 @@ class LmgtfyBot(token: String) extends ExampleBot(token)
       .withQuery(Query("q" -> query))
       .toString()
 
-  onCommand('pepe, 'lmgtfy2) { implicit msg =>
+  onCommand('btn, 'lmgtfy2) { implicit msg =>
     withArgs { args =>
       val query = args.mkString(" ")
       reply(query, replyMarkup = lmgtfyBtn(query))


### PR DESCRIPTION
There was an error in the Lmgtfy example, where _/pepe_ would trigger the _/lmgtfy2_ command, which should've been achieved by inserting _/btn_.

As stated in the help text, _/btn_ should be used for this command.