### PR TITLE
Make BotBase#logger protected

### DIFF
--- a/core/src/main/scala/info/mukel/telegrambot4s/api/BotBase.scala
+++ b/core/src/main/scala/info/mukel/telegrambot4s/api/BotBase.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
   */
 trait BotBase {
   def token: String
-  val logger: Logger
+  protected val logger: Logger
   val client: RequestHandler
 
   def request: RequestHandler = client


### PR DESCRIPTION
I'd like to use `StrictLogging`'s logger from https://github.com/typesafehub/scala-logging library this way:

`class MyBot extends BotBase with StrictLogging { ... }`

However, logger in `StrictLogging` is protected, so, it fails to compile without this patch.

Also, it just makes no sense to me to make logger public.